### PR TITLE
Make ALSA use nearest period.

### DIFF
--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -84,11 +84,13 @@ impl AudioOutputDevice for AlsaSoundDevice {
                 hw_params,
                 params.channels_count as u32,
             ))?;
-            check(snd_pcm_hw_params_set_period_size(
+            let mut exact_frame_count = frame_count as u64;
+            let mut exact_period = 0;
+            check(snd_pcm_hw_params_set_period_size_near(
                 playback_device,
                 hw_params,
-                frame_count as ::std::os::raw::c_ulong,
-                0,
+                &mut exact_frame_count,
+                &mut exact_period,
             ))?;
             let mut exact_size = (frame_count * 2) as ::std::os::raw::c_ulong;
             check(snd_pcm_hw_params_set_buffer_size_near(


### PR DESCRIPTION
Hello. I tried using Fyrox on my various machines where each had a different OS. My Nobara Linux machine crashed. I found that the issue was in the call to initialize tinyaudio. I made a test app to reproduce it:

    use tinyaudio::prelude::*; 
 
    fn main() { 
        let params = OutputDeviceParameters { 
            channels_count: 2, 
            sample_rate: 44100, 
            channel_sample_count: 4410, 
        }; 
 
        let _device = run_output_device(params, { 
            let mut clock = 0f32; 
            move |data| { 
                for samples in data.chunks_mut(params.channels_count) { 
                    clock = (clock + 1.0) % params.sample_rate as f32; 
                    let value = 
                        (clock * 440.0 * 2.0 * std::f32::consts::PI / params.sample_rate as f32).sin(); 
                    for sample in samples { 
                        *sample = value; 
                    } 
                } 
            } 
        }).unwrap(); 
 
        std::thread::sleep(std::time::Duration::from_secs(5)); 
    }

Once I had that in place, I tracked down the period size function being set to an exact value that ALSA didn't like on my machine. I saw that the `_near` variation was being used for some other functions, and got it to work.