### PR TITLE
alsa: fix some issues with 32-bit systems

### DIFF
--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -72,7 +72,7 @@ impl AudioOutputDevice for AlsaSoundDevice {
                 hw_params,
                 SND_PCM_FORMAT_S16_LE,
             ))?;
-            let mut exact_rate = params.sample_rate as u32;
+            let mut exact_rate = params.sample_rate as ::std::os::raw::c_uint;
             check(snd_pcm_hw_params_set_rate_near(
                 playback_device,
                 hw_params,
@@ -82,9 +82,9 @@ impl AudioOutputDevice for AlsaSoundDevice {
             check(snd_pcm_hw_params_set_channels(
                 playback_device,
                 hw_params,
-                params.channels_count as u32,
+                params.channels_count as ::std::os::raw::c_uint,
             ))?;
-            let mut _exact_period = frame_count as u64;
+            let mut _exact_period = frame_count as snd_pcm_uframes_t;
             let mut _direction = 0;
             check(snd_pcm_hw_params_set_period_size_near(
                 playback_device,


### PR DESCRIPTION
Hi, thanks for this crate!

Compilation for Raspberry PI failed because of 32-bit/64-bit mismatch in `_exact_period` argument to `snd_pcm_hw_params_set_period_size_near` so I've updated it to use `snd_pcm_uframes_t` as per the definition in the `alsa-sys` crate.

I also fixed two other casts to use the exact typings as the `alsa-sys` crate, even though they weren't causing compilation issues.

Tested compilation for x86_64 and Armv7.