### PR TITLE
Add ios-example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 rust-version = "1.56"
 
 [workspace]
-members = ["android-examples", "wasm-examples"]
+members = ["android-examples", "wasm-examples", "ios-example/Rust-TinyAudioExample"]
 
 # Make sure the separate examples (i.e. for Android or WebAssembly) will use the crate optimized.
 [profile.dev.package."*"]

--- a/ios-example/.gitignore
+++ b/ios-example/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/ios-example/README.md
+++ b/ios-example/README.md
@@ -1,0 +1,38 @@
+# TinyAudio example for iOS
+
+A very simple iOS app that plays a sine-wave at launch from a Rust library using TinyAudio  
+
+
+Requirements
+--
+- You need cargo-lipo to build the universal library:  
+`cargo install cargo-lipo`
+
+- The iOS project requires adding a link to the header file(s) from the rust project
+- Add/link other libraries:
+  - `AudioToolbox.framework`
+  - `libresolv.tbd`
+  - `libtinyaudioexample.a`
+
+Building
+--
+Just build and launch the iOS project normally, the Rust library will be automatically rebuilt each time
+
+Other details
+--
+
+The iOS project has 2 custom "Run Script Phases" in 'Build Phase' settings
+- First: build static library from the rust project  
+   `cargo lipo --xcode-integ --manifest-path $(PROJECT_DIR)../Rust-TinyAudioExample/Cargo.toml`
+
+- *... normal compile / link / bundle steps ...*
+   
+- Second: delete static library in rust project  
+   `rm -fv $(PROJECT_DIR)/../Rust-TinyAudioExample/target/universal/*/*.a`
+
+
+
+Useful links
+--
+- https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-06-rust-on-ios.html
+- https://github.com/TimNN/cargo-lipo?tab=readme-ov-file#xcode-integration

--- a/ios-example/Rust-TinyAudioExample/.gitignore
+++ b/ios-example/Rust-TinyAudioExample/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/ios-example/Rust-TinyAudioExample/Cargo.toml
+++ b/ios-example/Rust-TinyAudioExample/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "TinyAudioExample"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+name = "tinyaudioexample"
+
+[dependencies]
+tinyaudio = { path = "../../" }
+wasm-bindgen = "0.2.92"

--- a/ios-example/Rust-TinyAudioExample/audio.h
+++ b/ios-example/Rust-TinyAudioExample/audio.h
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int create_audio_device();
+int is_audio_initialized();
+void destroy_audio_device();

--- a/ios-example/Rust-TinyAudioExample/src/lib.rs
+++ b/ios-example/Rust-TinyAudioExample/src/lib.rs
@@ -1,0 +1,51 @@
+use tinyaudio::prelude::*;
+static mut DEVICE_HANDLE: Option<Box<dyn BaseAudioOutputDevice>> = None;
+
+#[no_mangle]
+pub extern "C" fn create_audio_device() -> i32 {
+    let params = OutputDeviceParameters {
+        channels_count: 2,
+        sample_rate: 44100,
+        channel_sample_count: 4410,
+    };
+
+    let device_result = run_output_device(params, {
+        let mut clock = 0f32;
+        move |data| {
+            for samples in data.chunks_mut(params.channels_count) {
+                clock = (clock + 1.0) % params.sample_rate as f32;
+                let value =
+                    (clock * 440.0 * 2.0 * std::f32::consts::PI / params.sample_rate as f32).sin();
+                for sample in samples {
+                    *sample = value;
+                }
+            }
+        }
+    });
+    match device_result {
+        Ok(device) => {
+            unsafe { DEVICE_HANDLE = Some(device); }
+            1
+        }
+        Err(_) => {
+            -1
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn is_audio_initialized() -> i32 {
+    unsafe {
+        match DEVICE_HANDLE.is_some() {
+            true => { 1 }
+            false => { 0 }
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn destroy_audio_device() {
+    unsafe {
+        DEVICE_HANDLE = None;
+    }
+}

--- a/ios-example/Rust-TinyAudioExample/src/lib.rs
+++ b/ios-example/Rust-TinyAudioExample/src/lib.rs
@@ -1,5 +1,6 @@
+#![cfg(target_os = "ios")]
 use tinyaudio::prelude::*;
-static mut DEVICE_HANDLE: Option<Box<dyn BaseAudioOutputDevice>> = None;
+static mut DEVICE_HANDLE: Option<OutputDevice> = None;
 
 #[no_mangle]
 pub extern "C" fn create_audio_device() -> i32 {

--- a/ios-example/TinyAudioExample/.gitignore
+++ b/ios-example/TinyAudioExample/.gitignore
@@ -1,0 +1,43 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+#Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/ios-example/TinyAudioExample/Audio-Bridging-Header.h
+++ b/ios-example/TinyAudioExample/Audio-Bridging-Header.h
@@ -1,0 +1,13 @@
+//
+//  Audio-Bridging-Header.h
+//  TinyAudioExample
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+#ifndef Audio_Bridging_Header_h
+#define Audio_Bridging_Header_h
+
+#import "audio.h"
+
+#endif /* Audio_Bridging_Header_h */

--- a/ios-example/TinyAudioExample/RustGreetings.swift
+++ b/ios-example/TinyAudioExample/RustGreetings.swift
@@ -1,0 +1,22 @@
+//
+//  RustGreetings.swift
+//  TinyAudioExample
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import Foundation
+
+class RustGreetings {
+    init () {
+        let status = create_audio_device();
+        print("RustGreetings::init() - status = ", status)
+    }
+    
+    func cleanup() {
+        print("RustGreetings::cleanup()")
+        if is_audio_initialized() > 0 {
+            destroy_audio_device();
+        }
+    }
+}

--- a/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.pbxproj
+++ b/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.pbxproj
@@ -1,0 +1,694 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		31E9BB962C532EF6008384E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BB952C532EF6008384E2 /* AppDelegate.swift */; };
+		31E9BB982C532EF6008384E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BB972C532EF6008384E2 /* SceneDelegate.swift */; };
+		31E9BB9A2C532EF6008384E2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BB992C532EF6008384E2 /* ViewController.swift */; };
+		31E9BB9D2C532EF6008384E2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 31E9BB9B2C532EF6008384E2 /* Main.storyboard */; };
+		31E9BB9F2C532EF8008384E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 31E9BB9E2C532EF8008384E2 /* Assets.xcassets */; };
+		31E9BBA22C532EF8008384E2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 31E9BBA02C532EF8008384E2 /* LaunchScreen.storyboard */; };
+		31E9BBAD2C532EF8008384E2 /* TinyAudioExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BBAC2C532EF8008384E2 /* TinyAudioExampleTests.swift */; };
+		31E9BBB72C532EF8008384E2 /* TinyAudioExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BBB62C532EF8008384E2 /* TinyAudioExampleUITests.swift */; };
+		31E9BBB92C532EF8008384E2 /* TinyAudioExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BBB82C532EF8008384E2 /* TinyAudioExampleUITestsLaunchTests.swift */; };
+		31E9BBCA2C533021008384E2 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E9BBC92C533018008384E2 /* libresolv.tbd */; };
+		31E9BBCE2C533283008384E2 /* RustGreetings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BBCD2C533283008384E2 /* RustGreetings.swift */; };
+		31E9BBDB2C535162008384E2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E9BBDA2C535162008384E2 /* AudioToolbox.framework */; };
+		31E9BBE22C546A62008384E2 /* libtinyaudioexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E9BBE12C546A13008384E2 /* libtinyaudioexample.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		31E9BBA92C532EF8008384E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 31E9BB8A2C532EF6008384E2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 31E9BB912C532EF6008384E2;
+			remoteInfo = TinyAudioExample;
+		};
+		31E9BBB32C532EF8008384E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 31E9BB8A2C532EF6008384E2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 31E9BB912C532EF6008384E2;
+			remoteInfo = TinyAudioExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		31E9BB922C532EF6008384E2 /* TinyAudioExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TinyAudioExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		31E9BB952C532EF6008384E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		31E9BB972C532EF6008384E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		31E9BB992C532EF6008384E2 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		31E9BB9C2C532EF6008384E2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		31E9BB9E2C532EF8008384E2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		31E9BBA12C532EF8008384E2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		31E9BBA32C532EF8008384E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		31E9BBA82C532EF8008384E2 /* TinyAudioExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinyAudioExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		31E9BBAC2C532EF8008384E2 /* TinyAudioExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinyAudioExampleTests.swift; sourceTree = "<group>"; };
+		31E9BBB22C532EF8008384E2 /* TinyAudioExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TinyAudioExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		31E9BBB62C532EF8008384E2 /* TinyAudioExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinyAudioExampleUITests.swift; sourceTree = "<group>"; };
+		31E9BBB82C532EF8008384E2 /* TinyAudioExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinyAudioExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		31E9BBC62C532F85008384E2 /* TinyAudioExample */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TinyAudioExample; path = ../../rust/ios/TinyAudioExample; sourceTree = "<group>"; };
+		31E9BBC72C532F9D008384E2 /* libgreetings.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgreetings.a; path = ../../rust/ios/TinyAudioExample/target/universal/release/libgreetings.a; sourceTree = "<group>"; };
+		31E9BBC92C533018008384E2 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
+		31E9BBCC2C5330A8008384E2 /* Audio-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Audio-Bridging-Header.h"; sourceTree = "<group>"; };
+		31E9BBCD2C533283008384E2 /* RustGreetings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustGreetings.swift; sourceTree = "<group>"; };
+		31E9BBCF2C534824008384E2 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		31E9BBDA2C535162008384E2 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		31E9BBDC2C535587008384E2 /* libtinyaudioexample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtinyaudioexample.a; path = ../../rust/ios/TinyAudioExample/target/universal/release/libtinyaudioexample.a; sourceTree = "<group>"; };
+		31E9BBDD2C53558C008384E2 /* libtinyaudioexample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtinyaudioexample.a; path = ../../rust/ios/TinyAudioExample/target/universal/debug/libtinyaudioexample.a; sourceTree = "<group>"; };
+		31E9BBE02C5357D5008384E2 /* audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio.h; path = "../Rust-TinyAudioExample/audio.h"; sourceTree = "<group>"; };
+		31E9BBE12C546A13008384E2 /* libtinyaudioexample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtinyaudioexample.a; path = ../../target/universal/debug/libtinyaudioexample.a; sourceTree = "<group>"; };
+		31E9BBE32C546A68008384E2 /* libtinyaudioexample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtinyaudioexample.a; path = ../../target/universal/release/libtinyaudioexample.a; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		31E9BB8F2C532EF6008384E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31E9BBDB2C535162008384E2 /* AudioToolbox.framework in Frameworks */,
+				31E9BBCA2C533021008384E2 /* libresolv.tbd in Frameworks */,
+				31E9BBE22C546A62008384E2 /* libtinyaudioexample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBA52C532EF8008384E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBAF2C532EF8008384E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		31E9BB892C532EF6008384E2 = {
+			isa = PBXGroup;
+			children = (
+				31E9BBE02C5357D5008384E2 /* audio.h */,
+				31E9BBCD2C533283008384E2 /* RustGreetings.swift */,
+				31E9BBCC2C5330A8008384E2 /* Audio-Bridging-Header.h */,
+				31E9BB942C532EF6008384E2 /* TinyAudioExample */,
+				31E9BBAB2C532EF8008384E2 /* TinyAudioExampleTests */,
+				31E9BBB52C532EF8008384E2 /* TinyAudioExampleUITests */,
+				31E9BB932C532EF6008384E2 /* Products */,
+				31E9BBC52C532F85008384E2 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		31E9BB932C532EF6008384E2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				31E9BB922C532EF6008384E2 /* TinyAudioExample.app */,
+				31E9BBA82C532EF8008384E2 /* TinyAudioExampleTests.xctest */,
+				31E9BBB22C532EF8008384E2 /* TinyAudioExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		31E9BB942C532EF6008384E2 /* TinyAudioExample */ = {
+			isa = PBXGroup;
+			children = (
+				31E9BB952C532EF6008384E2 /* AppDelegate.swift */,
+				31E9BB972C532EF6008384E2 /* SceneDelegate.swift */,
+				31E9BB992C532EF6008384E2 /* ViewController.swift */,
+				31E9BB9B2C532EF6008384E2 /* Main.storyboard */,
+				31E9BB9E2C532EF8008384E2 /* Assets.xcassets */,
+				31E9BBA02C532EF8008384E2 /* LaunchScreen.storyboard */,
+				31E9BBA32C532EF8008384E2 /* Info.plist */,
+			);
+			path = TinyAudioExample;
+			sourceTree = "<group>";
+		};
+		31E9BBAB2C532EF8008384E2 /* TinyAudioExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				31E9BBAC2C532EF8008384E2 /* TinyAudioExampleTests.swift */,
+			);
+			path = TinyAudioExampleTests;
+			sourceTree = "<group>";
+		};
+		31E9BBB52C532EF8008384E2 /* TinyAudioExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				31E9BBB62C532EF8008384E2 /* TinyAudioExampleUITests.swift */,
+				31E9BBB82C532EF8008384E2 /* TinyAudioExampleUITestsLaunchTests.swift */,
+			);
+			path = TinyAudioExampleUITests;
+			sourceTree = "<group>";
+		};
+		31E9BBC52C532F85008384E2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				31E9BBDC2C535587008384E2 /* libtinyaudioexample.a */,
+				31E9BBDD2C53558C008384E2 /* libtinyaudioexample.a */,
+				31E9BBE12C546A13008384E2 /* libtinyaudioexample.a */,
+				31E9BBE32C546A68008384E2 /* libtinyaudioexample.a */,
+				31E9BBDA2C535162008384E2 /* AudioToolbox.framework */,
+				31E9BBCF2C534824008384E2 /* CoreAudio.framework */,
+				31E9BBC92C533018008384E2 /* libresolv.tbd */,
+				31E9BBC72C532F9D008384E2 /* libgreetings.a */,
+				31E9BBC62C532F85008384E2 /* TinyAudioExample */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		31E9BB912C532EF6008384E2 /* TinyAudioExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 31E9BBBC2C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExample" */;
+			buildPhases = (
+				31E9BBD12C534CF1008384E2 /* Build Rust static library */,
+				31E9BB8E2C532EF6008384E2 /* Sources */,
+				31E9BB8F2C532EF6008384E2 /* Frameworks */,
+				31E9BB902C532EF6008384E2 /* Resources */,
+				31E9BBD62C534E53008384E2 /* Delete Rust static libraries */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TinyAudioExample;
+			productName = TinyAudioExample;
+			productReference = 31E9BB922C532EF6008384E2 /* TinyAudioExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		31E9BBA72C532EF8008384E2 /* TinyAudioExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 31E9BBBF2C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExampleTests" */;
+			buildPhases = (
+				31E9BBA42C532EF8008384E2 /* Sources */,
+				31E9BBA52C532EF8008384E2 /* Frameworks */,
+				31E9BBA62C532EF8008384E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				31E9BBAA2C532EF8008384E2 /* PBXTargetDependency */,
+			);
+			name = TinyAudioExampleTests;
+			productName = TinyAudioExampleTests;
+			productReference = 31E9BBA82C532EF8008384E2 /* TinyAudioExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		31E9BBB12C532EF8008384E2 /* TinyAudioExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 31E9BBC22C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExampleUITests" */;
+			buildPhases = (
+				31E9BBAE2C532EF8008384E2 /* Sources */,
+				31E9BBAF2C532EF8008384E2 /* Frameworks */,
+				31E9BBB02C532EF8008384E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				31E9BBB42C532EF8008384E2 /* PBXTargetDependency */,
+			);
+			name = TinyAudioExampleUITests;
+			productName = TinyAudioExampleUITests;
+			productReference = 31E9BBB22C532EF8008384E2 /* TinyAudioExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		31E9BB8A2C532EF6008384E2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					31E9BB912C532EF6008384E2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					31E9BBA72C532EF8008384E2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 31E9BB912C532EF6008384E2;
+					};
+					31E9BBB12C532EF8008384E2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 31E9BB912C532EF6008384E2;
+					};
+				};
+			};
+			buildConfigurationList = 31E9BB8D2C532EF6008384E2 /* Build configuration list for PBXProject "TinyAudioExample" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 31E9BB892C532EF6008384E2;
+			productRefGroup = 31E9BB932C532EF6008384E2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				31E9BB912C532EF6008384E2 /* TinyAudioExample */,
+				31E9BBA72C532EF8008384E2 /* TinyAudioExampleTests */,
+				31E9BBB12C532EF8008384E2 /* TinyAudioExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		31E9BB902C532EF6008384E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31E9BBA22C532EF8008384E2 /* LaunchScreen.storyboard in Resources */,
+				31E9BB9F2C532EF8008384E2 /* Assets.xcassets in Resources */,
+				31E9BB9D2C532EF6008384E2 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBA62C532EF8008384E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBB02C532EF8008384E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		31E9BBD12C534CF1008384E2 /* Build Rust static library */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Rust static library";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# The $PATH used by Xcode likely won't contain Cargo, fix that.\n# This assumes a default `rustup` setup.\nexport PATH=\"$HOME/.cargo/bin:$PATH\"\n\n# --xcode-integ determines --release and --targets from Xcode's env vars.\n# Depending your setup, specify the rustup toolchain explicitly.\ncargo lipo --xcode-integ --manifest-path $(PROJECT_DIR)../Rust-TinyAudioExample/Cargo.toml\n";
+		};
+		31E9BBD62C534E53008384E2 /* Delete Rust static libraries */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Delete Rust static libraries";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Delete the built libraries that were just linked.\n# If this isn't done, XCode won't try to rebuild them\n# by running the build scripts, because it won't think\n# they are out of date.\nrm -fv $(PROJECT_DIR)/../Rust-TinyAudioExample/target/universal/*/*.a\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		31E9BB8E2C532EF6008384E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31E9BBCE2C533283008384E2 /* RustGreetings.swift in Sources */,
+				31E9BB9A2C532EF6008384E2 /* ViewController.swift in Sources */,
+				31E9BB962C532EF6008384E2 /* AppDelegate.swift in Sources */,
+				31E9BB982C532EF6008384E2 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBA42C532EF8008384E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31E9BBAD2C532EF8008384E2 /* TinyAudioExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E9BBAE2C532EF8008384E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				31E9BBB92C532EF8008384E2 /* TinyAudioExampleUITestsLaunchTests.swift in Sources */,
+				31E9BBB72C532EF8008384E2 /* TinyAudioExampleUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		31E9BBAA2C532EF8008384E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 31E9BB912C532EF6008384E2 /* TinyAudioExample */;
+			targetProxy = 31E9BBA92C532EF8008384E2 /* PBXContainerItemProxy */;
+		};
+		31E9BBB42C532EF8008384E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 31E9BB912C532EF6008384E2 /* TinyAudioExample */;
+			targetProxy = 31E9BBB32C532EF8008384E2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		31E9BB9B2C532EF6008384E2 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				31E9BB9C2C532EF6008384E2 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		31E9BBA02C532EF8008384E2 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				31E9BBA12C532EF8008384E2 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		31E9BBBA2C532EF8008384E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		31E9BBBB2C532EF8008384E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		31E9BBBD2C532EF8008384E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TinyAudioExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../target/universal/$(CONFIGURATION:lower)";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Audio-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		31E9BBBE2C532EF8008384E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TinyAudioExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../target/universal/$(CONFIGURATION:lower)";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Audio-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		31E9BBC02C532EF8008384E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TinyAudioExample.app/TinyAudioExample";
+			};
+			name = Debug;
+		};
+		31E9BBC12C532EF8008384E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TinyAudioExample.app/TinyAudioExample";
+			};
+			name = Release;
+		};
+		31E9BBC32C532EF8008384E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TinyAudioExample;
+			};
+			name = Debug;
+		};
+		31E9BBC42C532EF8008384E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 687V3R575B;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chronx.TinyAudioExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TinyAudioExample;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		31E9BB8D2C532EF6008384E2 /* Build configuration list for PBXProject "TinyAudioExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				31E9BBBA2C532EF8008384E2 /* Debug */,
+				31E9BBBB2C532EF8008384E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		31E9BBBC2C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				31E9BBBD2C532EF8008384E2 /* Debug */,
+				31E9BBBE2C532EF8008384E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		31E9BBBF2C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				31E9BBC02C532EF8008384E2 /* Debug */,
+				31E9BBC12C532EF8008384E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		31E9BBC22C532EF8008384E2 /* Build configuration list for PBXNativeTarget "TinyAudioExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				31E9BBC32C532EF8008384E2 /* Debug */,
+				31E9BBC42C532EF8008384E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 31E9BB8A2C532EF6008384E2 /* Project object */;
+}

--- a/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios-example/TinyAudioExample/TinyAudioExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios-example/TinyAudioExample/TinyAudioExample/AppDelegate.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExample/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  TinyAudioExample
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/Contents.json
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-example/TinyAudioExample/TinyAudioExample/Base.lproj/LaunchScreen.storyboard
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios-example/TinyAudioExample/TinyAudioExample/Base.lproj/Main.storyboard
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios-example/TinyAudioExample/TinyAudioExample/Info.plist
+++ b/ios-example/TinyAudioExample/TinyAudioExample/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios-example/TinyAudioExample/TinyAudioExample/SceneDelegate.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExample/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  TinyAudioExample
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ios-example/TinyAudioExample/TinyAudioExample/ViewController.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExample/ViewController.swift
@@ -1,0 +1,50 @@
+//
+//  ViewController.swift
+//  TinyAudioExample
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+    
+    var handle: RustGreetings?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        
+        if handle == nil {
+            handle = RustGreetings()
+        }
+        
+        // Add observers for app state changes
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    @objc func handleAppWillResignActive() {
+        // Clean up the audio device
+        handle?.cleanup()
+        handle = nil
+    }
+
+    @objc func handleAppDidBecomeActive() {
+        // Re-initialize the audio device if needed
+        if handle == nil {
+            handle = RustGreetings()
+        }
+    }
+
+    deinit {
+        // Remove observers
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        
+        // Clean up the audio device
+        handle?.cleanup()
+        handle = nil
+    }
+}
+

--- a/ios-example/TinyAudioExample/TinyAudioExampleTests/TinyAudioExampleTests.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExampleTests/TinyAudioExampleTests.swift
@@ -1,0 +1,36 @@
+//
+//  TinyAudioExampleTests.swift
+//  TinyAudioExampleTests
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import XCTest
+@testable import TinyAudioExample
+
+class TinyAudioExampleTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ios-example/TinyAudioExample/TinyAudioExampleUITests/TinyAudioExampleUITests.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExampleUITests/TinyAudioExampleUITests.swift
@@ -1,0 +1,42 @@
+//
+//  TinyAudioExampleUITests.swift
+//  TinyAudioExampleUITests
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import XCTest
+
+class TinyAudioExampleUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ios-example/TinyAudioExample/TinyAudioExampleUITests/TinyAudioExampleUITestsLaunchTests.swift
+++ b/ios-example/TinyAudioExample/TinyAudioExampleUITests/TinyAudioExampleUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  TinyAudioExampleUITestsLaunchTests.swift
+//  TinyAudioExampleUITests
+//
+//  Created by Dustin Bowers on 7/25/24.
+//
+
+import XCTest
+
+class TinyAudioExampleUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
This PR includes:
- Rust project
- Xcode project

The Xcode project is configured to include the necessary C header file, link the required libraries, and build the rust library when the project is built. 

This example includes cleanup of the audio device when the App isn't active (otherwise the audio device would stay running even if the app is minimized)

(Also I'm not sure if it's appropriate to include the Xcode project in the example, because it makes some assumptions about usage. I've included it here because it actually does require a bit of setup to get Rust and Xcode to play nicely with each other)