### PR TITLE
migrate from "aaudio" crate to "ndk"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = ["android-examples", "wasm-examples", "ios-example/Rust-TinyAudioExamp
 opt-level = 3
 
 [target.'cfg(target_os = "android")'.dependencies]
-aaudio = "0.1.1"
+ndk = {version = "0.9.0", default-features = false, features = ["audio", "api-level-27"]}
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["minwindef", "winnt", "windef", "winuser", "dsound", "synchapi", "winbase"] }

--- a/src/aaudio.rs
+++ b/src/aaudio.rs
@@ -3,20 +3,21 @@
 #![cfg(target_os = "android")]
 
 use crate::{AudioOutputDevice, BaseAudioOutputDevice, OutputDeviceParameters};
-use aaudio::{
-    AAudioStream, AAudioStreamBuilder, CallbackResult, Direction, Format, PerformanceMode,
+use ndk::audio::{
+    AudioStream, AudioStreamBuilder, AudioCallbackResult, AudioDirection, AudioFormat, AudioPerformanceMode,
+    AudioError,
 };
 use std::error::Error;
 
 pub struct AAudioOutputDevice {
-    stream: AAudioStream,
+    stream: AudioStream,
 }
 
 impl BaseAudioOutputDevice for AAudioOutputDevice {}
 
 unsafe impl Send for AAudioOutputDevice {}
 
-fn convert_err(err: aaudio::Error) -> Box<dyn Error> {
+fn convert_err(err: AudioError) -> Box<dyn Error> {
     format!("{:?}", err).into()
 }
 
@@ -27,45 +28,37 @@ impl AudioOutputDevice for AAudioOutputDevice {
         Self: Sized,
     {
         let frame_count = params.channel_sample_count as i32;
-        let mut stream = AAudioStreamBuilder::new()
+        let mut stream = AudioStreamBuilder::new()
             .map_err(convert_err)?
             // Ensure double buffering is possible.
-            .set_buffer_capacity_in_frames(2 * frame_count)
-            .set_channel_count(params.channels_count as i32)
-            .set_format(Format::F32)
-            .set_sample_rate(params.sample_rate as i32)
-            .set_direction(Direction::Output)
-            .set_performance_mode(PerformanceMode::LowLatency)
+            .buffer_capacity_in_frames(2 * frame_count)
+            .channel_count(params.channels_count as i32)
+            .format(AudioFormat::PCM_Float)
+            .sample_rate(params.sample_rate as i32)
+            .direction(AudioDirection::Output)
+            .performance_mode(AudioPerformanceMode::LowLatency)
             // Force the AAudio to give the buffer of fixed size.
-            .set_frames_per_data_callback(frame_count)
-            .set_callbacks(
-                move |_, data, num_frames| {
+            .frames_per_data_callback(frame_count)
+            .data_callback(
+                Box::new(move |_, data, num_frames| {
                     let output_data = unsafe {
                         std::slice::from_raw_parts_mut::<f32>(
-                            data.as_mut_ptr() as *mut f32,
+                            data as *mut f32,
                             num_frames as usize * params.channels_count,
                         )
                     };
 
                     data_callback(output_data);
 
-                    CallbackResult::Continue
-                },
-                |_, error| eprintln!("AAudio: an error has occurred - {:?}", error),
+                    AudioCallbackResult::Continue
+                })
             )
+            .error_callback(Box::new(|_, error| eprintln!("AAudio: an error has occurred - {:?}", error)))
             .open_stream()
             .map_err(convert_err)?;
 
         stream.request_start().map_err(convert_err)?;
 
         Ok(Self { stream })
-    }
-}
-
-impl Drop for AAudioOutputDevice {
-    fn drop(&mut self) {
-        self.stream
-            .release()
-            .expect("Failed to release the stream!")
     }
 }

--- a/src/aaudio.rs
+++ b/src/aaudio.rs
@@ -10,7 +10,7 @@ use ndk::audio::{
 use std::error::Error;
 
 pub struct AAudioOutputDevice {
-    stream: AudioStream,
+    _stream: AudioStream,
 }
 
 impl BaseAudioOutputDevice for AAudioOutputDevice {}
@@ -28,7 +28,7 @@ impl AudioOutputDevice for AAudioOutputDevice {
         Self: Sized,
     {
         let frame_count = params.channel_sample_count as i32;
-        let mut stream = AudioStreamBuilder::new()
+        let stream = AudioStreamBuilder::new()
             .map_err(convert_err)?
             // Ensure double buffering is possible.
             .buffer_capacity_in_frames(2 * frame_count)
@@ -59,6 +59,6 @@ impl AudioOutputDevice for AAudioOutputDevice {
 
         stream.request_start().map_err(convert_err)?;
 
-        Ok(Self { stream })
+        Ok(Self { _stream: stream })
     }
 }


### PR DESCRIPTION
This is the only audio lib that I use for game dev in rust, thanks for publishing.

I had some difficulties to compile "aaudio" for my own android device. (android 8 armv7)

As "aaudio" crate is not maintaind for almost 5 years, "ndk" is a good up to date replacment and requires only few changes in tinyaudio source code. 
