### PR TITLE
Added freebsd to allowed targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ features = [
     "AudioDestinationNode"
 ]
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 alsa-sys = { version = "0.3.1", optional = true }
 libpulse-sys = { version = "1.23.0", optional = true }
 

--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -1,6 +1,6 @@
 //! Linux output device via `alsa`.
 
-#![cfg(all(target_os = "linux", feature = "alsa"))]
+#![cfg(all(any(target_os = "linux", target_os = "freebsd"), feature = "alsa"))]
 
 use crate::{AudioOutputDevice, BaseAudioOutputDevice, OutputDeviceParameters};
 use alsa_sys::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ where
         )?));
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     {
         #[cfg(feature = "alsa")]
         {
@@ -176,6 +176,7 @@ where
     #[cfg(not(any(
         target_os = "windows",
         target_os = "linux",
+        target_os = "freebsd",
         target_os = "android",
         target_os = "macos",
         target_os = "ios",

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -1,6 +1,6 @@
 //! Linux output device via `PulseAudio`.
 
-#![cfg(all(target_os = "linux", feature = "pulse"))]
+#![cfg(all(any(target_os = "linux", target_os = "freebsd"), feature = "pulse"))]
 #![cfg_attr(feature = "alsa", allow(dead_code))]
 
 use crate::{AudioOutputDevice, BaseAudioOutputDevice, OutputDeviceParameters};


### PR DESCRIPTION
FreeBSD uses the same audio backends (ALSA/PulseAudio) as Linux. Hence, adding FreeBSD support was just a matter of allowing it. I’ve changed the `#[cfg(target)]` flags to allow that, and tested it on my FreeBSD machine (15.1-RELEASE-p3).